### PR TITLE
refactor: migrate frontend to MVVM architecture

### DIFF
--- a/frontend/app/(tabs)/apps/store.tsx
+++ b/frontend/app/(tabs)/apps/store.tsx
@@ -20,17 +20,9 @@ import SignInMessage from "@/components/SignInMessage";
 import SignInModal from "@/components/SignInModal";
 import { Colors } from "@/constants/Colors";
 import { NOT_DOWNLOADED } from "@/constants/Constants";
-import { AppDispatch, RootState } from "@/context/store";
-import {
-  downloadMicroApp,
-  loadMicroAppDetails,
-  removeMicroApp,
-} from "@/services/appStoreService";
-import { logout } from "@/services/authService";
-import { useEffect, useRef, useState } from "react";
+import { useStore } from "@/hooks/useStore";
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Keyboard,
   StyleSheet,
@@ -39,138 +31,24 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { useDispatch, useSelector } from "react-redux";
 
 const Store = () => {
-  const dispatch = useDispatch();
-  const { apps, downloading } = useSelector((state: RootState) => state.apps);
-  const { accessToken } = useSelector((state: RootState) => state.auth);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const [searchQuery, setSearchQuery] = useState<string>("");
-  const [filteredApps, setFilteredApps] = useState(apps);
-  const [installationQueue, setInstallationQueue] = useState<
-    {
-      appId: string;
-      downloadUrl: string;
-    }[]
-  >([]);
-  const [isProcessingQueue, setIsProcessingQueue] = useState(false);
-
-  const isMountedRef = useRef(true);
-  const activeDownloadsRef = useRef(new Set<string>());
-
   const colorScheme = useColorScheme();
   const styles = createStyles(colorScheme ?? "light");
 
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  // load micro apps list
-  useEffect(() => {
-    const initializeApps = async () => {
-      setIsLoading(true);
-      if (accessToken) loadMicroAppDetails(dispatch, logout);
-      setIsLoading(false);
-    };
-
-    initializeApps();
-  }, [dispatch, accessToken]);
-
-  const handleRemoveMicroApp = async (dispatch: AppDispatch, appId: string) => {
-    Alert.alert(
-      "Confirm Removal",
-      "Are you sure you want to remove this app?",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Remove",
-          style: "destructive",
-          onPress: async () => {
-            await removeMicroApp(dispatch, appId, logout);
-          },
-        },
-      ]
-    );
-  };
-
-  // Filter apps based on search query
-  useEffect(() => {
-    if (searchQuery.trim() === "") {
-      setFilteredApps(apps);
-    } else {
-      const filtered = apps.filter(
-        (app) =>
-          app.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          app.description.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      setFilteredApps(filtered);
-    }
-  }, [searchQuery, apps]);
-
-  // Process the installation queue
-  useEffect(() => {
-    const processQueue = async () => {
-      if (isProcessingQueue || installationQueue.length === 0) return;
-
-      setIsProcessingQueue(true);
-      const currentItem = installationQueue[0];
-
-      try {
-        activeDownloadsRef.current.add(currentItem.appId);
-
-        await downloadMicroApp(
-          dispatch,
-          currentItem.appId,
-          currentItem.downloadUrl,
-          logout
-        );
-
-        if (isMountedRef.current) {
-          setInstallationQueue((prev) => prev.slice(1));
-        }
-      } catch (error) {
-        console.error("Installation failed:", error);
-        Alert.alert("Error", "Installation failed try again later");
-        setInstallationQueue((prev) => prev.slice(1));
-        dispatch({
-          type: "REMOVE_DOWNLOADING_APP",
-          payload: currentItem.appId,
-        });
-      } finally {
-        activeDownloadsRef.current.delete(currentItem.appId);
-        if (isMountedRef.current) {
-          setIsProcessingQueue(false);
-        }
-      }
-    };
-
-    processQueue();
-  }, [installationQueue, isProcessingQueue, dispatch]);
-
-  // Modified download handler to create a serialized task queue
-  const handleDownload = (appId: string, downloadUrl: string) => {
-    //if not logged in, show signin
-    if (!accessToken) {
-      setShowModal(true);
-      return;
-    }
-
-    // Check if already in queue or downloading
-    const isAlreadyQueued = installationQueue.some(
-      (item) => item.appId === appId
-    );
-    const isCurrentlyDownloading = activeDownloadsRef.current.has(appId);
-
-    if (!isAlreadyQueued && !isCurrentlyDownloading) {
-      setInstallationQueue((prev) => [...prev, { appId, downloadUrl }]);
-      dispatch({ type: "ADD_DOWNLOADING_APP", payload: appId });
-    }
-  };
+  const {
+    accessToken,
+    filteredApps,
+    downloading,
+    installationQueue,
+    isLoading,
+    showModal,
+    setShowModal,
+    searchQuery,
+    setSearchQuery,
+    handleDownload,
+    handleRemoveMicroApp,
+  } = useStore();
 
   // When default apps added need to remove this logic
   if (!accessToken) {
@@ -234,7 +112,7 @@ const Store = () => {
                 onDownload={() =>
                   handleDownload(item.appId, item.versions[0].downloadUrl)
                 }
-                onRemove={() => handleRemoveMicroApp(dispatch, item.appId)}
+                onRemove={() => handleRemoveMicroApp(item.appId)}
               />
               {/* Horizontal Line */}
               {index !== filteredApps.length - 1 && (

--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -22,15 +22,14 @@ import {
   Dimensions,
   useWindowDimensions
 } from "react-native";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import FeedSkeleton from "@/components/FeedSkeleton";
 import { Colors } from "@/constants/Colors";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { useTrackActiveScreen } from "@/hooks/useTrackActiveScreen";
-import useNewsFeed from "@/hooks/useNewsFeed";
+import { useFeed } from "@/hooks/useFeed";
 import News from "@/components/News";
-import useEventsFeed from "@/hooks/useEventsFeed";
 import Event from "@/components/Event";
 import BannerSlider from "@/components/BannerSlider";
 import { router } from "expo-router";
@@ -45,30 +44,15 @@ const Discovery = () => {
   const colorScheme = useColorScheme();
   const { height: windowHeightDynamic } = useWindowDimensions();
   const styles = createStyles(colorScheme ?? "light", tabBarHeight, windowHeightDynamic);
-  const [isMinTimeElapsed, setIsMinTimeElapsed] = useState(false);
 
   useTrackActiveScreen(ScreenPaths.FEED);
-  const { newsItems, loading } = useNewsFeed();
-  const { eventItems } = useEventsFeed();
 
-  useEffect(() => {
-    /**
-     * Delays rendering of the main content for a minimum of 1 second to ensure that
-     * the skeleton UI is displayed briefly. This helps prevent the issue where the
-     * index page content flashes too quickly and causes a poor visual experience
-     * (especially when the app initially loads on the default screen).
-     */
-    const timer = setTimeout(() => {
-      setIsMinTimeElapsed(true);
-    }, 1000); // 1 second
-
-    return () => clearTimeout(timer);
-  }, []);
+  const { newsItems, eventItems, shouldShowSkeleton, isEmpty } = useFeed();
 
 
   return (
     <View style={styles.background}>
-      {!isMinTimeElapsed || loading ? (
+      {shouldShowSkeleton ? (
         <FeedSkeleton />
       ) : (
         <ScrollView style={{ padding: 16, marginTop: 5 }}>
@@ -103,7 +87,7 @@ const Discovery = () => {
           )}
 
           {/* if no events or news items are available  visit my app tab for microapps*/}
-          {(!eventItems || eventItems.length === 0) && (!newsItems || newsItems.length === 0) && (
+          {isEmpty && (
             // should be in center of screen with disabled text color 
                 <View style={styles.emptyNewsEventsContainer}>
                   <Ionicons 

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -18,109 +18,23 @@ import {
   DefaultTheme,
   ThemeProvider,
 } from "@react-navigation/native";
-import { useFonts } from "expo-font";
 import { Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
-import { useCallback, useEffect, useState } from "react";
-import { useColorScheme } from "@/hooks/useColorScheme";
-import { Provider, useDispatch } from "react-redux";
-import { PersistGate } from "redux-persist/integration/react";
-import { AppDispatch, persistor, store } from "@/context/store";
-import AsyncStorage from "@react-native-async-storage/async-storage";
-import { setApps } from "@/context/slices/appSlice";
-import { APPS, USER_INFO } from "@/constants/Constants";
-import { getUserConfigurations } from "@/context/slices/userConfigSlice";
-import { restoreAuth } from "@/context/slices/authSlice";
-import { getVersions } from "@/context/slices/versionSlice";
-import { setUserInfo } from "@/context/slices/userInfoSlice";
-import SplashModal from "@/components/SplashModal";
-import { performLogout } from "@/utils/performLogout";
-import { lockAsync, OrientationLock } from "expo-screen-orientation";
 import * as SplashScreen from "expo-splash-screen";
+import { useColorScheme } from "@/hooks/useColorScheme";
+import { useAppLayout } from "@/hooks/useAppLayout";
+import { Provider } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
+import { persistor, store } from "@/context/store";
+import SplashModal from "@/components/SplashModal";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-
-// Component to handle app initialization
-function AppInitializer({ onReady }: { onReady: () => void }) {
-  const dispatch = useDispatch<AppDispatch>(); // Ensure correct typing for async actions
-  const handleLogout = async () => {
-    await dispatch(performLogout()).unwrap(); // Ensure the logout action is dispatched properly
-  };
-
-  useEffect(() => {
-    const initialize = async () => {
-      try {
-        const [savedApps, savedUserInfo] = await Promise.all([
-          AsyncStorage.getItem(APPS),
-          AsyncStorage.getItem(USER_INFO),
-        ]);
-
-        if (savedApps) dispatch(setApps(JSON.parse(savedApps)));
-        if (savedUserInfo) dispatch(setUserInfo(JSON.parse(savedUserInfo)));
-
-        dispatch(getVersions(handleLogout));
-        dispatch(getUserConfigurations(handleLogout));
-        await dispatch(restoreAuth()).unwrap();
-      } catch (error) {
-        console.error("Initialization error:", error);
-      } finally {
-        onReady();
-      }
-    };
-
-    initialize();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
-
-  return null; // No UI rendering needed
-}
+import AppInitializer from "../components/AppInitializer";
 
 // Main Root Layout
 export default function RootLayout() {
   SplashScreen.hide();
   const colorScheme = useColorScheme();
-  const [isAppReady, setIsAppReady] = useState(false);
-  const [isMinTimeElapsed, setIsMinTimeElapsed] = useState(false);
-  const [fontsLoaded] = useFonts({
-    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
-  });
-
-  // Called when all app initialization is done
-  const onAppLoadComplete = useCallback(() => {
-    if (fontsLoaded) {
-      setIsAppReady(true);
-    }
-  }, [fontsLoaded]);
-
-  // Start timer on first render
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsMinTimeElapsed(true);
-    }, 2000); // 2 seconds
-
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Trigger initialization when fonts are ready
-  useEffect(() => {
-    if (fontsLoaded) {
-      onAppLoadComplete();
-    }
-  }, [fontsLoaded, onAppLoadComplete]);
-
-  const showSplash = !isAppReady || !isMinTimeElapsed;
-
-  // Lock screen orientation to portrait mode
-  useEffect(() => {
-    const lockOrientation = async () => {
-      try {
-        await lockAsync(OrientationLock.PORTRAIT_UP);
-      } catch (error) {
-        console.error("Error locking orientation:", error);
-      }
-    };
-
-    lockOrientation();
-  }, []);
+  const { showSplash, onAppLoadComplete } = useAppLayout();
 
   if (showSplash) {
     return <SplashModal loading={showSplash} animationType="fade" />;

--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -17,27 +17,15 @@ import NotFound from "@/components/NotFound";
 import Scanner from "@/components/Scanner";
 import { Colors } from "@/constants/Colors";
 import {
-  DEVELOPER_APP_DEFAULT_URL,
   FULL_SCREEN_VIEWING_MODE,
-  GOOGLE_ANDROID_CLIENT_ID,
-  GOOGLE_IOS_CLIENT_ID,
-  GOOGLE_SCOPES,
-  GOOGLE_WEB_CLIENT_ID,
-  isAndroid,
   isIos,
 } from "@/constants/Constants";
-import { logout, tokenExchange } from "@/services/authService";
-import googleAuthenticationService from "@/services/googleService";
 import { MicroAppParams } from "@/types/navigation";
 import { injectedJavaScript } from "@/utils/bridge";
-import { getBridgeHandler, getResolveMethod, getRejectMethod } from "@/utils/bridgeRegistry";
-import { BridgeContext } from "@/types/bridge.types";
-import * as Google from "expo-auth-session/providers/google";
 import { documentDirectory } from "expo-file-system";
-import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import * as WebBrowser from "expo-web-browser";
-import { useEffect, useRef, useState } from "react";
 import {
   Alert,
   StyleSheet,
@@ -47,174 +35,33 @@ import {
   View,
 } from "react-native";
 import prompt from "react-native-prompt-android";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { WebView, WebViewMessageEvent } from "react-native-webview";
-import { useDispatch, useSelector } from "react-redux";
+import { WebView } from "react-native-webview";
+import { useMicroApp } from "@/hooks/useMicroApp";
 
 WebBrowser.maybeCompleteAuthSession();
-import { BRIDGE_FUNCTION as QR_REQUEST_BRIDGE_FUNCTION } from "@/utils/bridgeHandlers/qrRequest";
 
 const MicroApp = () => {
-  const [isScannerVisible, setScannerVisible] = useState(false);
-
-  const { webViewUri, appName, clientId, exchangedToken, appId, displayMode } =
-    useLocalSearchParams<MicroAppParams>();
-  const [hasError, setHasError] = useState(false);
-  const webviewRef = useRef<WebView>(null);
-  const [token, setToken] = useState<string | null>();
-  const dispatch = useDispatch();
-  const router = useRouter();
-  const pendingTokenRequestsRef = useRef<((token: string) => void)[]>([]);
-  const qrScanCallbackRef = useRef<((qrCode: string) => void) | null>(null);
-  const [webUri, setWebUri] = useState<string>(DEVELOPER_APP_DEFAULT_URL);
+  const params = useLocalSearchParams<MicroAppParams>();
+  const { webViewUri, appName, displayMode } = params;
+  
   const colorScheme = useColorScheme();
   const styles = createStyles(colorScheme ?? "light");
-  const isDeveloper: boolean = appId.includes("developer");
-  const isTotp: boolean = appId.includes("totp");
-  const insets = useSafeAreaInsets();
   const shouldShowHeader: boolean = displayMode !== FULL_SCREEN_VIEWING_MODE;
 
-  const [request, response, promptAsync] = Google.useAuthRequest({
-    iosClientId: GOOGLE_IOS_CLIENT_ID,
-    webClientId: GOOGLE_WEB_CLIENT_ID,
-    androidClientId: GOOGLE_ANDROID_CLIENT_ID,
-    scopes: GOOGLE_SCOPES,
-  });
-
-  // Function to send response to micro app
-  const sendResponseToWeb = (method: string, data?: any) => {
-    webviewRef.current?.injectJavaScript(
-      `window.nativebridge.${method}(${JSON.stringify(data)});`
-    );
-  };
-
-  // Handle Google authentication response
-  useEffect(() => {
-    if (response) {
-      googleAuthenticationService(response)
-        .then((res) => {
-          if (res.status) {
-            sendResponseToWeb("resolveGoogleLogin", res.userInfo);
-          } else {
-            sendResponseToWeb("rejectGoogleLogin", res.error);
-          }
-        })
-        .catch((err) => {
-          console.error("Google authentication error:", err);
-          sendResponseToWeb("rejectGoogleLogin", err.message);
-        });
-    }
-  }, [response]);
-
-  useEffect(() => {
-    const fetchToken = async () => {
-      try {
-        const token = await tokenExchange(
-          dispatch,
-          clientId,
-          exchangedToken,
-          appId,
-          logout
-        );
-        if (!token) throw new Error("Token exchange failed");
-        setToken(token);
-        sendTokenToWebView(token);
-      } catch (error) {
-        console.error("Token exchange error:", error);
-      }
-    };
-
-    fetchToken();
-  }, [clientId]);
-
-  // Function to send token to WebView
-  const sendTokenToWebView = (token: string) => {
-    if (!token) return;
-    sendResponseToWeb("resolveToken", token);
-
-    // Resolve any pending token requests
-    while (pendingTokenRequestsRef.current.length > 0) {
-      const resolve = pendingTokenRequestsRef.current.shift();
-      resolve?.(token);
-    }
-  };
-
-  // Handle messages from WebView
-  const onMessage = async (event: WebViewMessageEvent) => {
-   try {
-      const { topic, data, requestId } = JSON.parse(event.nativeEvent.data);
-      if (!topic) throw new Error("Invalid message format: Missing topic");
-
-      // Get handler from registry
-      const handler = getBridgeHandler(topic);
-      if (!handler) {
-        console.error("Unknown topic:", topic);
-        return;
-      }
-
-      // Create bridge context for passing data
-      const bridgeContext: BridgeContext = {
-        topic,
-        appID: appId as string,
-        token: token || null, // exchanged token
-        setScannerVisible,
-
-        sendResponseToWeb: (method: string, data?: any, reqId?: string) => {
-          const idToUse = reqId || requestId;
-          webviewRef.current?.injectJavaScript(
-            `window.nativebridge.${method}(${JSON.stringify(data)}, "${idToUse}");`
-          );
-        },
-        pendingTokenRequests: pendingTokenRequestsRef.current,
-
-        resolve: (data?: any, reqId?: string) => {
-          const methodName = getResolveMethod(topic);
-          const idToUse = reqId || requestId;
-          webviewRef.current?.injectJavaScript(
-            `window.nativebridge.${methodName}(${JSON.stringify(data)}, "${idToUse}");`
-          );
-        },
-        reject: (error: string, reqId?: string) => {
-          const methodName = getRejectMethod(topic);
-          const idToUse = reqId || requestId;
-          webviewRef.current?.injectJavaScript(
-            `window.nativebridge.${methodName}("${error}", "${idToUse}");`
-          );
-        },
-        // Google authentication
-        promptAsync,
-        // Navigation
-        router,
-        // Device info
-        insets: {
-          top: insets.top,
-          bottom: insets.bottom,
-          left: insets.left,
-          right: insets.right,
-        },
-        // QR scanner callback
-        qrScanCallback: qrScanCallbackRef.current || undefined,
-      };
-      await handler(data, bridgeContext);
-
-      // Update the ref with any callback set by the handler
-      if (topic === QR_REQUEST_BRIDGE_FUNCTION.topic) {
-        qrScanCallbackRef.current = bridgeContext.qrScanCallback || null;
-      }
-    } catch (error) {
-      console.error("Error handling WebView message:", error);
-    }
-  };
-
-  const handleError = (syntheticEvent: any) => {
-    setHasError(true);
-    console.error("WebView error:", syntheticEvent.nativeEvent);
-  };
-
-  const reloadWebView = () => {
-    setHasError(false);
-    webviewRef.current?.reload();
-  };
+  const {
+    isScannerVisible,
+    hasError,
+    webUri,
+    isDeveloper,
+    isTotp,
+    insets,
+    webviewRef,
+    onMessage,
+    handleError,
+    reloadWebView,
+    handleQRScan,
+    handleChangeWebUri,
+  } = useMicroApp(params);
 
   const renderWebView = (webViewUri: string) => {
     // Check if web view uri is available
@@ -286,75 +133,66 @@ const MicroApp = () => {
           title: shouldShowHeader ? appName : "",
           headerShown: shouldShowHeader,
           headerRight: () =>
-            isDeveloper ? (
-            shouldShowHeader && (
+            isDeveloper && shouldShowHeader ? (
               <TouchableOpacity
                 onPressIn={() => {
-                  isIos
-                    ? Alert.prompt(
-                        "App URL",
-                        "Enter App URL",
-                        [
-                          {
-                            text: "Cancel",
-                            style: "cancel",
-                          },
-                          {
-                            text: "OK",
-                            onPress: (value) => {
-                              if (value) {
-                                setWebUri(value);
-                              }
-                            },
-                          },
-                        ],
-                        "plain-text",
-                        webUri
-                      )
-                    : prompt(
-                        "App URL",
-                        "Enter App URL",
-                        [
-                          {
-                            text: "Cancel",
-                            onPress: () => console.log("Cancel Pressed"),
-                            style: "cancel",
-                          },
-                          {
-                            text: "OK",
-                            onPress: (value) => {
-                              if (value) {
-                                setWebUri(value);
-                              }
-                            },
-                            style: "default",
-                          },
-                        ],
+                  if (isIos) {
+                    Alert.prompt(
+                      "App URL",
+                      "Enter App URL",
+                      [
                         {
-                          type: "plain-text",
-                          cancelable: false,
-                          defaultValue: webUri,
-                        }
-                      );
+                          text: "Cancel",
+                          style: "cancel",
+                        },
+                        {
+                          text: "OK",
+                          onPress: (value) => {
+                            handleChangeWebUri(value);
+                          },
+                        },
+                      ],
+                      "plain-text",
+                      webUri
+                    );
+                  } else {
+                    prompt(
+                      "App URL",
+                      "Enter App URL",
+                      [
+                        {
+                          text: "Cancel",
+                          onPress: () => console.log("Cancel Pressed"),
+                          style: "cancel",
+                        },
+                        {
+                          text: "OK",
+                          onPress: (value) => {
+                            handleChangeWebUri(value);
+                          },
+                          style: "default",
+                        },
+                      ],
+                      {
+                        type: "plain-text",
+                        cancelable: false,
+                        defaultValue: webUri,
+                      }
+                    );
+                  }
                 }}
                 hitSlop={20}
               >
                 <Text style={styles.headerText}>App URL</Text>
               </TouchableOpacity>
-            )) : null,
+            ) : null,
         }}
       />
       <View style={styles.container}>
         {isScannerVisible && (
           <View style={styles.scannerOverlay}>
             <Scanner
-              onScan={(qrCode) => {
-                // Call the stored callback from the bridge handler
-                if (qrScanCallbackRef.current) {
-                  qrScanCallbackRef.current(qrCode);
-                }
-                setScannerVisible(false);
-              }}
+              onScan={handleQRScan}
               message={
                 isTotp
                   ? "We need access to your camera to scan QR codes for generating one-time passwords (TOTP) for secure authentication. This will allow you to easily log in to your accounts."

--- a/frontend/components/AppInitializer.tsx
+++ b/frontend/components/AppInitializer.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { AppDispatch } from "@/context/store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { setApps } from "@/context/slices/appSlice";
+import { APPS, USER_INFO } from "@/constants/Constants";
+import { getUserConfigurations } from "@/context/slices/userConfigSlice";
+import { restoreAuth } from "@/context/slices/authSlice";
+import { getVersions } from "@/context/slices/versionSlice";
+import { setUserInfo } from "@/context/slices/userInfoSlice";
+import { performLogout } from "@/utils/performLogout";
+
+/**
+ * Component to handle app initialization
+ * Loads persisted data and initializes app state
+ */
+function AppInitializer({ onReady }: { onReady: () => void }) {
+  const dispatch = useDispatch<AppDispatch>();
+  
+  const handleLogout = async () => {
+    await dispatch(performLogout()).unwrap();
+  };
+
+  useEffect(() => {
+    const initialize = async () => {
+      try {
+        const [savedApps, savedUserInfo] = await Promise.all([
+          AsyncStorage.getItem(APPS),
+          AsyncStorage.getItem(USER_INFO),
+        ]);
+
+        if (savedApps) dispatch(setApps(JSON.parse(savedApps)));
+        if (savedUserInfo) dispatch(setUserInfo(JSON.parse(savedUserInfo)));
+
+        dispatch(getVersions(handleLogout));
+        dispatch(getUserConfigurations(handleLogout));
+        await dispatch(restoreAuth()).unwrap();
+      } catch (error) {
+        console.error("Initialization error:", error);
+      } finally {
+        onReady();
+      }
+    };
+
+    initialize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch]);
+
+  return null;
+}
+
+export default AppInitializer;

--- a/frontend/hooks/useAppLayout.ts
+++ b/frontend/hooks/useAppLayout.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useCallback, useEffect, useState } from "react";
+import { useFonts } from "expo-font";
+import { lockAsync, OrientationLock } from "expo-screen-orientation";
+
+/**
+ * Hook for managing root app layout initialization
+ */
+export const useAppLayout = () => {
+  const [isAppReady, setIsAppReady] = useState(false);
+  const [isMinTimeElapsed, setIsMinTimeElapsed] = useState(false);
+  
+  const [fontsLoaded] = useFonts({
+    SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
+  });
+
+  // Called when all app initialization is done
+  const onAppLoadComplete = useCallback(() => {
+    if (fontsLoaded) {
+      setIsAppReady(true);
+    }
+  }, [fontsLoaded]);
+
+  // Minimum splash screen time
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsMinTimeElapsed(true);
+    }, 2000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Trigger initialization when fonts are ready
+  useEffect(() => {
+    if (fontsLoaded) {
+      onAppLoadComplete();
+    }
+  }, [fontsLoaded, onAppLoadComplete]);
+
+  // Lock screen orientation to portrait mode
+  useEffect(() => {
+    const lockOrientation = async () => {
+      try {
+        await lockAsync(OrientationLock.PORTRAIT_UP);
+      } catch (error) {
+        console.error("Error locking orientation:", error);
+      }
+    };
+
+    lockOrientation();
+  }, []);
+
+  const showSplash = !isAppReady || !isMinTimeElapsed;
+
+  return {
+    showSplash,
+    onAppLoadComplete,
+  };
+};

--- a/frontend/hooks/useFeed.ts
+++ b/frontend/hooks/useFeed.ts
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import useNewsFeed from "./useNewsFeed";
+import useEventsFeed from "./useEventsFeed";
+
+/**
+ * Hook for managing Feed/Discovery screen content
+ */
+export const useFeed = () => {
+  const [isMinTimeElapsed, setIsMinTimeElapsed] = useState(false);
+  const { newsItems, loading: newsLoading } = useNewsFeed();
+  const { eventItems, loading: eventsLoading } = useEventsFeed();
+
+  const loading = newsLoading || eventsLoading;
+  const isEmpty = (!eventItems || eventItems.length === 0) && 
+                  (!newsItems || newsItems.length === 0);
+
+  useEffect(() => {
+    /**
+     * Delays rendering of the main content for a minimum of 1 second to ensure that
+     * the skeleton UI is displayed briefly. This helps prevent the issue where the
+     * index page content flashes too quickly and causes a poor visual experience
+     * (especially when the app initially loads on the default screen).
+     */
+    const timer = setTimeout(() => {
+      setIsMinTimeElapsed(true);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return {
+    newsItems,
+    eventItems,
+    loading,
+    isMinTimeElapsed,
+    isEmpty,
+    shouldShowSkeleton: !isMinTimeElapsed || loading,
+  };
+};

--- a/frontend/hooks/useLibrary.ts
+++ b/frontend/hooks/useLibrary.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import { fetchLibraryArticles } from "@/services/libraryService";
+import { LibraryArticle } from "@/types/library.types";
+import { LIBRARY_ARTICLE_FETCH_LIMIT } from "@/constants/Constants";
+import useDebounce from "./useDebounce";
+
+/**
+ * Hook for managing library articles with pagination and search
+ */
+export const useLibrary = () => {
+  const [articles, setArticles] = useState<LibraryArticle[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [fetchingMore, setFetchingMore] = useState<boolean>(false);
+  const [start, setStart] = useState<number>(0);
+  const [hasMore, setHasMore] = useState<boolean>(true);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+
+  const debouncedQuery = useDebounce(searchQuery, 500);
+
+  const fetchArticles = async (
+    isInitial: boolean = false,
+    query: string = ""
+  ) => {
+    if (!hasMore && !isInitial) return;
+
+    if (isInitial) {
+      setLoading(true);
+      setStart(0);
+      setHasMore(true);
+    } else {
+      setFetchingMore(true);
+    }
+
+    try {
+      const data = await fetchLibraryArticles(isInitial, start, query);
+      const newArticles: LibraryArticle[] = data;
+      
+      if (isInitial) {
+        setArticles(newArticles);
+      } else {
+        setArticles((prev) => [...prev, ...newArticles]);
+      }
+
+      if (newArticles.length < LIBRARY_ARTICLE_FETCH_LIMIT) {
+        setHasMore(false);
+      } else {
+        setStart((prev) => prev + LIBRARY_ARTICLE_FETCH_LIMIT);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      if (isInitial) {
+        setLoading(false);
+      } else {
+        setFetchingMore(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const handleQuery = async () => {
+      const trimmedQuery = debouncedQuery.trim();
+
+      if (trimmedQuery.length === 0) {
+        fetchArticles(true);
+        return;
+      }
+
+      if (trimmedQuery.length < 3) return;
+
+      fetchArticles(true, trimmedQuery);
+    };
+
+    handleQuery();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQuery]);
+
+  const loadMore = () => {
+    if (!fetchingMore && hasMore) {
+      fetchArticles(false, debouncedQuery);
+    }
+  };
+
+  return {
+    articles,
+    loading,
+    fetchingMore,
+    searchQuery,
+    setSearchQuery,
+    loadMore,
+  };
+};

--- a/frontend/hooks/useMicroApp.ts
+++ b/frontend/hooks/useMicroApp.ts
@@ -1,0 +1,237 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { useDispatch } from "react-redux";
+import { useRouter } from "expo-router";
+import { WebView, WebViewMessageEvent } from "react-native-webview";
+import * as Google from "expo-auth-session/providers/google";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { tokenExchange } from "@/services/authService";
+import { logout } from "@/services/authService";
+import googleAuthenticationService from "@/services/googleService";
+import { getBridgeHandler, getResolveMethod, getRejectMethod } from "@/utils/bridgeRegistry";
+import { BridgeContext } from "@/types/bridge.types";
+import { BRIDGE_FUNCTION as QR_REQUEST_BRIDGE_FUNCTION } from "@/utils/bridgeHandlers/qrRequest";
+import {
+  GOOGLE_ANDROID_CLIENT_ID,
+  GOOGLE_IOS_CLIENT_ID,
+  GOOGLE_WEB_CLIENT_ID,
+  GOOGLE_SCOPES,
+  DEVELOPER_APP_DEFAULT_URL,
+} from "@/constants/Constants";
+
+interface MicroAppParams {
+  webViewUri: string;
+  appName: string;
+  clientId: string;
+  exchangedToken: string;
+  appId: string;
+  displayMode?: string;
+}
+
+/**
+ * Hook for managing MicroApp WebView bridge and state
+ */
+export const useMicroApp = (params: MicroAppParams) => {
+  const { clientId, exchangedToken, appId } = params;
+  
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  
+  const [isScannerVisible, setScannerVisible] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [token, setToken] = useState<string | null>();
+  const [webUri, setWebUri] = useState<string>(DEVELOPER_APP_DEFAULT_URL);
+  
+  const webviewRef = useRef<WebView>(null);
+  const pendingTokenRequestsRef = useRef<((token: string) => void)[]>([]);
+  const qrScanCallbackRef = useRef<((qrCode: string) => void) | null>(null);
+
+  const isDeveloper: boolean = appId.includes("developer");
+  const isTotp: boolean = appId.includes("totp");
+
+  // Google Auth
+  const [, response, promptAsync] = Google.useAuthRequest({
+    iosClientId: GOOGLE_IOS_CLIENT_ID,
+    webClientId: GOOGLE_WEB_CLIENT_ID,
+    androidClientId: GOOGLE_ANDROID_CLIENT_ID,
+    scopes: GOOGLE_SCOPES,
+  });
+
+  // Send response to micro app
+  const sendResponseToWeb = (method: string, data?: any) => {
+    webviewRef.current?.injectJavaScript(
+      `window.nativebridge.${method}(${JSON.stringify(data)});`
+    );
+  };
+
+  // Handle Google authentication response
+  useEffect(() => {
+    if (response) {
+      googleAuthenticationService(response)
+        .then((res) => {
+          if (res.status) {
+            sendResponseToWeb("resolveGoogleLogin", res.userInfo);
+          } else {
+            sendResponseToWeb("rejectGoogleLogin", res.error);
+          }
+        })
+        .catch((err) => {
+          console.error("Google authentication error:", err);
+          sendResponseToWeb("rejectGoogleLogin", err.message);
+        });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [response]);
+
+  // Token exchange
+  useEffect(() => {
+    const fetchToken = async () => {
+      try {
+        const token = await tokenExchange(
+          dispatch,
+          clientId,
+          exchangedToken,
+          appId,
+          logout
+        );
+        if (!token) throw new Error("Token exchange failed");
+        setToken(token);
+        sendTokenToWebView(token);
+      } catch (error) {
+        console.error("Token exchange error:", error);
+      }
+    };
+
+    fetchToken();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clientId]);
+
+  const sendTokenToWebView = (token: string) => {
+    if (!token) return;
+    sendResponseToWeb("resolveToken", token);
+
+    while (pendingTokenRequestsRef.current.length > 0) {
+      const resolve = pendingTokenRequestsRef.current.shift();
+      resolve?.(token);
+    }
+  };
+
+  // Handle WebView messages
+  const onMessage = async (event: WebViewMessageEvent) => {
+    try {
+      const { topic, data, requestId } = JSON.parse(event.nativeEvent.data);
+      if (!topic) throw new Error("Invalid message format: Missing topic");
+
+      const handler = getBridgeHandler(topic);
+      if (!handler) {
+        console.error("Unknown topic:", topic);
+        return;
+      }
+
+      const bridgeContext: BridgeContext = {
+        topic,
+        appID: appId as string,
+        token: token || null,
+        setScannerVisible,
+        sendResponseToWeb: (method: string, data?: any, reqId?: string) => {
+          const idToUse = reqId || requestId;
+          webviewRef.current?.injectJavaScript(
+            `window.nativebridge.${method}(${JSON.stringify(data)}, "${idToUse}");`
+          );
+        },
+        pendingTokenRequests: pendingTokenRequestsRef.current,
+        resolve: (data?: any, reqId?: string) => {
+          const methodName = getResolveMethod(topic);
+          const idToUse = reqId || requestId;
+          webviewRef.current?.injectJavaScript(
+            `window.nativebridge.${methodName}(${JSON.stringify(data)}, "${idToUse}");`
+          );
+        },
+        reject: (error: string, reqId?: string) => {
+          const methodName = getRejectMethod(topic);
+          const idToUse = reqId || requestId;
+          webviewRef.current?.injectJavaScript(
+            `window.nativebridge.${methodName}("${error}", "${idToUse}");`
+          );
+        },
+        promptAsync,
+        router,
+        insets: {
+          top: insets.top,
+          bottom: insets.bottom,
+          left: insets.left,
+          right: insets.right,
+        },
+        qrScanCallback: qrScanCallbackRef.current || undefined,
+      };
+
+      await handler(data, bridgeContext);
+
+      if (topic === QR_REQUEST_BRIDGE_FUNCTION.topic) {
+        qrScanCallbackRef.current = bridgeContext.qrScanCallback || null;
+      }
+    } catch (error) {
+      console.error("Error handling WebView message:", error);
+    }
+  };
+
+  const handleError = (syntheticEvent: any) => {
+    setHasError(true);
+    console.error("WebView error:", syntheticEvent.nativeEvent);
+  };
+
+  const reloadWebView = () => {
+    setHasError(false);
+    webviewRef.current?.reload();
+  };
+
+  const handleQRScan = (qrCode: string) => {
+    if (qrScanCallbackRef.current) {
+      qrScanCallbackRef.current(qrCode);
+    }
+    setScannerVisible(false);
+  };
+
+  const handleChangeWebUri = (value: string | undefined) => {
+    if (value) {
+      setWebUri(value);
+    }
+  };
+
+  return {
+    // State
+    isScannerVisible,
+    hasError,
+    webUri,
+    isDeveloper,
+    isTotp,
+    insets,
+    
+    // Refs
+    webviewRef,
+    
+    // Handlers
+    onMessage,
+    handleError,
+    reloadWebView,
+    handleQRScan,
+    handleChangeWebUri,
+    setWebUri,
+  };
+};

--- a/frontend/hooks/useMyApps.ts
+++ b/frontend/hooks/useMyApps.ts
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState } from "react";
+import { Alert } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/context/store";
+import { MicroApp } from "@/context/slices/appSlice";
+import {
+  downloadMicroApp,
+  loadMicroAppDetails,
+  removeMicroApp,
+} from "@/services/appStoreService";
+import { logout } from "@/services/authService";
+import { getUserConfigurations } from "@/context/slices/userConfigSlice";
+import { APP_LIST_CONFIG_KEY, DOWNLOADED } from "@/constants/Constants";
+import { router } from "expo-router";
+import { ScreenPaths } from "@/constants/ScreenPaths";
+import Constants from "expo-constants";
+
+/**
+ * Hook for managing My Apps screen
+ */
+export const useMyApps = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const apps = useSelector((state: RootState) => state.apps.apps);
+  const { email } = useSelector((state: RootState) => state.auth);
+  const { versions, loading: versionsLoading } = useSelector(
+    (state: RootState) => state.version
+  );
+  const userConfigurations = useSelector(
+    (state: RootState) => state.userConfig.configurations
+  );
+
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [filteredApps, setFilteredApps] = useState(apps);
+  const [syncing, setSyncing] = useState(false);
+  const [currentAction, setCurrentAction] = useState<string | null>(null);
+  const [progress, setProgress] = useState<{ done: number; total: number }>({
+    done: 0,
+    total: 0,
+  });
+
+  const version = Constants.expoConfig?.version;
+
+  // Check for app updates
+  useEffect(() => {
+    const checkVersion = () => {
+      if (version && Array.isArray(versions) && versions.length > 0) {
+        if (versions[0]?.version > version) {
+          router.replace(ScreenPaths.UPDATE);
+        }
+      }
+    };
+
+    checkVersion();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [versions, versionsLoading]);
+
+  // Initialize app data
+  useEffect(() => {
+    const initializeApp = async () => {
+      try {
+        if (!apps || apps.length === 0) {
+          await loadMicroAppDetails(dispatch, logout);
+        }
+        if (!userConfigurations || userConfigurations.length === 0) {
+          dispatch(getUserConfigurations(logout));
+        }
+      } catch (error) {
+        console.error("Error during app initialization:", error);
+        Alert.alert(
+          "Initialization Error",
+          "An error occurred while setting up the app. Please restart and try again."
+        );
+      }
+    };
+
+    initializeApp();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [email]);
+
+  // Sync apps with user configuration
+  useEffect(() => {
+    const syncApps = async () => {
+      setSyncing(true);
+      setProgress({ done: 0, total: 0 });
+      setCurrentAction(null);
+
+      try {
+        const userConfigAppIds = userConfigurations.find(
+          (config) => config.configKey === APP_LIST_CONFIG_KEY
+        );
+
+        const allowedApps = (userConfigAppIds?.configValue as string[]) || [];
+
+        const localApps: MicroApp[] = apps.filter(
+          (app) => app?.status === DOWNLOADED
+        );
+
+        const localAppIds = localApps.map((app) => app.appId);
+        const appsToRemove = localAppIds.filter(
+          (appId) => !allowedApps.includes(appId)
+        );
+        const appsToInstall = allowedApps.filter(
+          (appId) => !localAppIds.includes(appId)
+        );
+
+        const totalSteps = appsToRemove.length + appsToInstall.length;
+        setProgress({ done: 0, total: totalSteps });
+
+        // Remove apps
+        for (const appId of appsToRemove) {
+          const appData = apps.find((app) => app.appId === appId);
+          setCurrentAction(`Removing ${appData?.name || appId}`);
+          await removeMicroApp(dispatch, appId, logout);
+          setProgress((prev) => ({ ...prev, done: prev.done + 1 }));
+        }
+
+        let updatedApps = localApps.filter(
+          (app) => !appsToRemove.includes(app.appId)
+        );
+
+        // Install apps
+        for (const appId of appsToInstall) {
+          const appData = apps.find((app) => app.appId === appId);
+          if (appData) {
+            setCurrentAction(`Downloading ${appData.name}`);
+            await downloadMicroApp(
+              dispatch,
+              appId,
+              appData.versions?.[0]?.downloadUrl,
+              logout
+            );
+            updatedApps.push({
+              ...appData,
+              status: DOWNLOADED,
+            });
+            setProgress((prev) => ({ ...prev, done: prev.done + 1 }));
+          }
+        }
+      } catch (error) {
+        console.error("App sync failed:", error);
+      } finally {
+        setCurrentAction(null);
+        setSyncing(false);
+      }
+    };
+
+    if (userConfigurations && userConfigurations.length > 0) syncApps();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, userConfigurations]);
+
+  // Filter apps based on search
+  useEffect(() => {
+    const downloadedApps = apps.filter((app) => app?.status === DOWNLOADED);
+    if (searchQuery.trim() === "") {
+      setFilteredApps(downloadedApps);
+    } else {
+      const filtered = downloadedApps.filter((app) =>
+        app.name.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+      setFilteredApps(filtered);
+    }
+  }, [searchQuery, apps]);
+
+  return {
+    filteredApps,
+    searchQuery,
+    setSearchQuery,
+    syncing,
+    currentAction,
+    progress,
+  };
+};

--- a/frontend/hooks/useProfile.ts
+++ b/frontend/hooks/useProfile.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useState, useCallback } from "react";
+import { Alert } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/context/store";
+import { getUserInfo } from "@/context/slices/userInfoSlice";
+import { logout } from "@/services/authService";
+import { jwtDecode } from "jwt-decode";
+import { DecodedAccessToken } from "@/types/decodeAccessToken.types";
+import { BasicUserInfo } from "@/types/basicUserInfo.types";
+import { performLogout } from "@/utils/performLogout";
+
+/**
+ * Hook for managing profile/user authentication state
+ */
+export const useProfile = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { accessToken } = useSelector((state: RootState) => state.auth);
+  const { userInfo } = useSelector((state: RootState) => state.userInfo);
+  
+  const [basicUserInfo, setBasicUserInfo] = useState<BasicUserInfo>({
+    firstName: "",
+    lastName: "",
+    workEmail: "",
+    avatarUri: "",
+  });
+
+  useEffect(() => {
+    if (userInfo) {
+      const qualityUserThumbnail = userInfo.userThumbnail
+        ? userInfo.userThumbnail.split("=s100")[0]
+        : "";
+      setBasicUserInfo({
+        firstName: userInfo.firstName,
+        lastName: userInfo.lastName,
+        workEmail: userInfo.workEmail,
+        avatarUri: qualityUserThumbnail,
+      });
+    }
+  }, [userInfo]);
+
+  useEffect(() => {
+    if (accessToken && !userInfo) {
+      dispatch(getUserInfo(logout));
+
+      try {
+        const decoded = jwtDecode<DecodedAccessToken>(accessToken);
+        setBasicUserInfo({
+          firstName: decoded.given_name || "",
+          lastName: decoded.family_name || "",
+          workEmail: decoded.email || "",
+          avatarUri: "",
+        });
+      } catch (error) {
+        console.error("Error decoding token", error);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken, dispatch]);
+
+  const handleLogout = useCallback(() => {
+    Alert.alert(
+      "Confirm Sign Out",
+      "Are you sure you want to sign out from this app?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Sign Out",
+          style: "destructive",
+          onPress: async () => {
+            await dispatch(performLogout());
+          },
+        },
+      ]
+    );
+  }, [dispatch]);
+
+  return {
+    accessToken,
+    basicUserInfo,
+    handleLogout,
+  };
+};

--- a/frontend/hooks/useStore.ts
+++ b/frontend/hooks/useStore.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { useEffect, useRef, useState } from "react";
+import { Alert } from "react-native";
+import { useDispatch, useSelector } from "react-redux";
+import { AppDispatch, RootState } from "@/context/store";
+import {
+  downloadMicroApp,
+  loadMicroAppDetails,
+  removeMicroApp,
+} from "@/services/appStoreService";
+import { logout } from "@/services/authService";
+
+/**
+ * Hook for managing Store screen - app downloads and removals
+ */
+export const useStore = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { apps, downloading } = useSelector((state: RootState) => state.apps);
+  const { accessToken } = useSelector((state: RootState) => state.auth);
+
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [filteredApps, setFilteredApps] = useState(apps);
+  const [installationQueue, setInstallationQueue] = useState<
+    { appId: string; downloadUrl: string }[]
+  >([]);
+  const [isProcessingQueue, setIsProcessingQueue] = useState(false);
+
+  const isMountedRef = useRef(true);
+  const activeDownloadsRef = useRef(new Set<string>());
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  // Load micro apps list
+  useEffect(() => {
+    const initializeApps = async () => {
+      setIsLoading(true);
+      if (accessToken) loadMicroAppDetails(dispatch, logout);
+      setIsLoading(false);
+    };
+
+    initializeApps();
+  }, [dispatch, accessToken]);
+
+  // Filter apps based on search query
+  useEffect(() => {
+    if (searchQuery.trim() === "") {
+      setFilteredApps(apps);
+    } else {
+      const filtered = apps.filter(
+        (app) =>
+          app.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          app.description.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+      setFilteredApps(filtered);
+    }
+  }, [searchQuery, apps]);
+
+  // Process the installation queue
+  useEffect(() => {
+    const processQueue = async () => {
+      if (isProcessingQueue || installationQueue.length === 0) return;
+
+      setIsProcessingQueue(true);
+      const currentItem = installationQueue[0];
+
+      try {
+        activeDownloadsRef.current.add(currentItem.appId);
+
+        await downloadMicroApp(
+          dispatch,
+          currentItem.appId,
+          currentItem.downloadUrl,
+          logout
+        );
+
+        if (isMountedRef.current) {
+          setInstallationQueue((prev) => prev.slice(1));
+        }
+      } catch (error) {
+        console.error("Installation failed:", error);
+        Alert.alert("Error", "Installation failed try again later");
+        setInstallationQueue((prev) => prev.slice(1));
+        dispatch({
+          type: "REMOVE_DOWNLOADING_APP",
+          payload: currentItem.appId,
+        });
+      } finally {
+        activeDownloadsRef.current.delete(currentItem.appId);
+        if (isMountedRef.current) {
+          setIsProcessingQueue(false);
+        }
+      }
+    };
+
+    processQueue();
+  }, [installationQueue, isProcessingQueue, dispatch]);
+
+  const handleDownload = (appId: string, downloadUrl: string) => {
+    if (!accessToken) {
+      setShowModal(true);
+      return;
+    }
+
+    const isAlreadyQueued = installationQueue.some(
+      (item) => item.appId === appId
+    );
+    const isCurrentlyDownloading = activeDownloadsRef.current.has(appId);
+
+    if (!isAlreadyQueued && !isCurrentlyDownloading) {
+      setInstallationQueue((prev) => [...prev, { appId, downloadUrl }]);
+      dispatch({ type: "ADD_DOWNLOADING_APP", payload: appId });
+    }
+  };
+
+  const handleRemoveMicroApp = async (appId: string) => {
+    Alert.alert(
+      "Confirm Removal",
+      "Are you sure you want to remove this app?",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Remove",
+          style: "destructive",
+          onPress: async () => {
+            await removeMicroApp(dispatch, appId, logout);
+          },
+        },
+      ]
+    );
+  };
+
+  return {
+    accessToken,
+    filteredApps,
+    downloading,
+    installationQueue,
+    isLoading,
+    showModal,
+    setShowModal,
+    searchQuery,
+    setSearchQuery,
+    handleDownload,
+    handleRemoveMicroApp,
+  };
+};


### PR DESCRIPTION
## Summary
This PR migrates the frontend to MVVM architecture using custom hooks as ViewModels.

## Changes
- Extract business logic from screens into custom hooks (ViewModels)
- Create reusable hooks: useFeed, useLibrary, useProfile, useMyApps, useStore, useMicroApp, useAppLayout
- Add AppInitializer component for app state initialization

## Impact
- Screens are now pure presentational components
- Business logic is centralized in hooks for better testability
- Improved code maintainability and reusability