### PR TITLE
fix(frontend): Keep downloaded micro-app status across sign-out

### DIFF
--- a/frontend/utils/performLogout.ts
+++ b/frontend/utils/performLogout.ts
@@ -13,7 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import { APPS, AUTH_DATA, USER_INFO } from "@/constants/Constants";
+import { AUTH_DATA, USER_INFO } from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { resetAll } from "@/context/slices/authSlice";
 import { persistor, RootState } from "@/context/store";
@@ -60,7 +60,6 @@ export const performLogout = createAsyncThunk(
       await clearAllExchangedTokens(appIds);
       
       await AsyncStorage.removeItem(USER_INFO);
-      await AsyncStorage.removeItem(APPS);
 
       Alert.alert(
         "Logout Successful",


### PR DESCRIPTION
## Purpose
User downloaded micro-apps are get wiped after the user sign outs from the mobile app.

## Goals
Keep downloaded micro-app status across sign-out

## Approach
Remove the function that wipes the downloaded micro-apps details that stored in the AsyncStorage.

## Test environment
Build with EAS and tested locally. Also made the internal test release with changes and verified the mobile app perform as expected.