### PR TITLE
[Frontend]: Add skeleton loading for micro-app fetching, and loading feedback for sign-out

### DIFF
--- a/frontend/app/(tabs)/_layout.tsx
+++ b/frontend/app/(tabs)/_layout.tsx
@@ -16,12 +16,14 @@
 import { HapticTab } from "@/components/HapticTab";
 import TabBarBackground from "@/components/ui/TabBarBackground";
 import { Colors } from "@/constants/Colors";
+import { RootState } from "@/context/store";
 import { useRestoreLastTab } from "@/hooks/useRestoreLastTab";
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
-import { Platform } from "react-native";
+import { Platform, View } from "react-native";
 import { Href } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useSelector } from "react-redux";
 
 type TabType = {
   name: string;
@@ -71,53 +73,73 @@ export default function TabLayout() {
   // Load last active tab and navigate to it
   useRestoreLastTab();
   const insets = useSafeAreaInsets();
+  const isLoggingOut = useSelector((state: RootState) => state.auth.isLoggingOut);
+  const tabBarHeight = 60 + insets.bottom;
 
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: Colors.companyOrange,
-        headerShown: true,
-        tabBarButton: HapticTab,
-        tabBarBackground: TabBarBackground,
-        tabBarStyle: Platform.select({
-          ios: {
+    <>
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: Colors.companyOrange,
+          headerShown: true,
+          tabBarButton: HapticTab,
+          tabBarBackground: TabBarBackground,
+          tabBarStyle: Platform.select({
+            ios: {
+              position: "absolute",
+              paddingTop: 5,
+            },
+            android: {
+              height: tabBarHeight,
+              paddingTop: 5,
+              paddingBottom: insets.bottom,
+              borderTopWidth: 0,
+              elevation: 0,
+            },
+            default: {
+              height: 60,
+              paddingTop: 5,
+            },
+          }),
+        }}
+      >
+        {tabs.map((tab, index) => (
+          <Tabs.Screen
+            key={`tab-${index}`}
+            name={tab.name}
+            options={{
+              tabBarAccessibilityLabel: `tab_${tab.name}`,
+              headerShown: tab.options.headerShown,
+              title: tab.options.title,
+              headerTitleAllowFontScaling: false,
+              href: tab.options.href,
+              tabBarIcon: ({ focused, color }) => (
+                <Ionicons
+                  name={focused ? tab.options.iconFocused : tab.options.icon}
+                  size={28}
+                  color={color}
+                />
+              ),
+            }}
+          />
+        ))}
+      </Tabs>
+      {/* Blocks all touches on the tab bar while signing out, regardless of
+          whether tabBarButton's disabled prop is honored by the tab bar's
+          internal rendering. */}
+      {isLoggingOut && (
+        <View
+          pointerEvents="auto"
+          style={{
             position: "absolute",
-            paddingTop: 5,
-          },
-          android: {
-            height: 60 + insets.bottom,
-            paddingTop: 5,
-            paddingBottom: insets.bottom,
-            borderTopWidth: 0,
-            elevation: 0,
-          },
-          default: {
-            height: 60,
-            paddingTop: 5,
-          },
-        }),
-      }}
-    >
-      {tabs.map((tab, index) => (
-        <Tabs.Screen
-          key={`tab-${index}`}
-          name={tab.name}
-          options={{
-            tabBarAccessibilityLabel: `tab_${tab.name}`,
-            headerShown: tab.options.headerShown,
-            title: tab.options.title,
-            headerTitleAllowFontScaling: false,
-            href: tab.options.href,
-            tabBarIcon: ({ focused, color }) => (
-              <Ionicons
-                name={focused ? tab.options.iconFocused : tab.options.icon}
-                size={28}
-                color={color}
-              />
-            ),
+            left: 0,
+            right: 0,
+            bottom: 0,
+            height: tabBarHeight,
+            zIndex: 999,
           }}
         />
-      ))}
-    </Tabs>
+      )}
+    </>
   );
 }

--- a/frontend/app/(tabs)/apps/index.tsx
+++ b/frontend/app/(tabs)/apps/index.tsx
@@ -30,6 +30,7 @@ import SyncingModal from "@/components/SyncingModal";
 import { Colors } from "@/constants/Colors";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import SearchBar from "@/components/SearchBar";
+import { WidgetSkeletonGrid } from "@/components/WidgetSkeleton";
 import { useTrackActiveScreen } from "@/hooks/useTrackActiveScreen";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { useMyApps } from "@/hooks/useMyApps";
@@ -46,6 +47,7 @@ export default function HomeScreen() {
     filteredApps,
     searchQuery,
     setSearchQuery,
+    isLoading,
     syncing,
     currentAction,
     progress,
@@ -72,7 +74,10 @@ export default function HomeScreen() {
         progress={progress}
       />
 
-      <View style={{ marginTop: 16 }}>
+      <View style={{ marginTop: 16, paddingHorizontal: 16 }}>
+        {isLoading ? (
+          <WidgetSkeletonGrid />
+        ) : (
         <FlatList
           data={filteredApps}
           keyExtractor={(item) => item.appId}
@@ -117,6 +122,7 @@ export default function HomeScreen() {
             </>
           }
         />
+        )}
       </View>
     </SafeAreaView>
   );

--- a/frontend/app/(tabs)/apps/store.tsx
+++ b/frontend/app/(tabs)/apps/store.tsx
@@ -15,6 +15,7 @@
 // under the License.
 
 import ListItem from "@/components/ListItem";
+import { ListItemSkeletonList } from "@/components/ListItemSkeleton";
 import SearchBar from "@/components/SearchBar";
 import SignInMessage from "@/components/SignInMessage";
 import SignInModal from "@/components/SignInModal";
@@ -22,7 +23,6 @@ import { Colors } from "@/constants/Colors";
 import { NOT_DOWNLOADED } from "@/constants/Constants";
 import { useStore } from "@/hooks/useStore";
 import {
-  ActivityIndicator,
   FlatList,
   Keyboard,
   StyleSheet,
@@ -82,10 +82,8 @@ const Store = () => {
 
       <SignInModal visible={showModal} onClose={() => setShowModal(false)} />
       {isLoading ? (
-        <View
-          style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
-        >
-          <ActivityIndicator color={Colors.companyOrange} size="large" />
+        <View style={styles.listContent}>
+          <ListItemSkeletonList />
         </View>
       ) : (
         <FlatList

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -20,6 +20,7 @@ import {
   useColorScheme,
   StyleSheet,
   Image,
+  ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import React from "react";
@@ -43,7 +44,7 @@ const SettingsScreen = () => {
 
   useTrackActiveScreen(ScreenPaths.PROFILE);
 
-  const { basicUserInfo, handleLogout } = useProfile();
+  const { basicUserInfo, handleLogout, isLoggingOut } = useProfile();
 
   return (
     <SafeAreaView style={styles.container} edges={['left', 'right']}>
@@ -85,17 +86,28 @@ const SettingsScreen = () => {
 
         <TouchableOpacity
           activeOpacity={0.5}
-          style={styles.logoutButton}
+          style={[styles.logoutButton, isLoggingOut && styles.logoutButtonDisabled]}
           onPress={handleLogout}
+          disabled={isLoggingOut}
         >
           <View style={styles.logoutRow}>
-            <Ionicons
-              name="log-out-outline"
-              size={20}
-              color={Colors[colorScheme ?? "light"].primaryBackgroundColor}
-              style={styles.logoutIcon}
-            />
-            <Text style={styles.logoutText}>Sign Out</Text>
+            {isLoggingOut ? (
+              <ActivityIndicator
+                size="small"
+                color={Colors[colorScheme ?? "light"].primaryBackgroundColor}
+                style={styles.logoutIcon}
+              />
+            ) : (
+              <Ionicons
+                name="log-out-outline"
+                size={20}
+                color={Colors[colorScheme ?? "light"].primaryBackgroundColor}
+                style={styles.logoutIcon}
+              />
+            )}
+            <Text style={styles.logoutText}>
+              {isLoggingOut ? "Signing Out..." : "Sign Out"}
+            </Text>
           </View>
         </TouchableOpacity>
       </View>
@@ -144,6 +156,9 @@ const createStyles = (colorScheme: "light" | "dark") =>
       borderRadius: 12,
       alignItems: "center",
       justifyContent: "center",
+    },
+    logoutButtonDisabled: {
+      opacity: 0.7,
     },
     logoutRow: {
       flexDirection: "row",

--- a/frontend/components/ListItemSkeleton.tsx
+++ b/frontend/components/ListItemSkeleton.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import React from "react";
+import { View, StyleSheet, Dimensions } from "react-native";
+import { Skeleton } from "./Skeleton";
+
+const ListItemSkeleton = () => {
+  const screenWidth = Dimensions.get("window").width;
+
+  return (
+    <View style={[styles.container, { width: screenWidth - 24 }]}>
+      <Skeleton width={66} height={66} borderRadius={12} />
+      <View style={styles.infoContainer}>
+        <Skeleton width="70%" height={16} style={{ marginBottom: 8 }} />
+        <Skeleton width="90%" height={12} style={{ marginBottom: 8 }} />
+        <Skeleton width="30%" height={10} />
+      </View>
+      <Skeleton width={70} height={32} borderRadius={8} />
+    </View>
+  );
+};
+
+export const ListItemSkeletonList = ({ count = 6 }: { count?: number }) => (
+  <>
+    {Array.from({ length: count }).map((_, index) => (
+      <ListItemSkeleton key={index} />
+    ))}
+  </>
+);
+
+export default ListItemSkeleton;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    marginHorizontal: 12,
+    marginTop: 16,
+    marginBottom: 16,
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  infoContainer: {
+    marginLeft: 16,
+    justifyContent: "center",
+    flex: 1,
+  },
+});

--- a/frontend/components/WidgetSkeleton.tsx
+++ b/frontend/components/WidgetSkeleton.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Skeleton } from "./Skeleton";
+
+const WidgetSkeleton = () => (
+  <View style={styles.container}>
+    <Skeleton width={66} height={66} borderRadius={12} />
+    <Skeleton width={48} height={10} style={{ marginTop: 8 }} />
+  </View>
+);
+
+export const WidgetSkeletonGrid = ({ count = 8 }: { count?: number }) => (
+  <View style={styles.grid}>
+    {Array.from({ length: count }).map((_, index) => (
+      <WidgetSkeleton key={index} />
+    ))}
+  </View>
+);
+
+export default WidgetSkeleton;
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+  container: {
+    width: "25%",
+    marginBottom: 24,
+    alignItems: "center",
+    paddingHorizontal: 4,
+  },
+});

--- a/frontend/context/slices/authSlice.ts
+++ b/frontend/context/slices/authSlice.ts
@@ -29,6 +29,7 @@ interface AuthState {
   idToken: string | null;
   email: AuthData["email"] | null;
   isLoading: boolean;
+  isLoggingOut: boolean;
 }
 
 const initialState: AuthState = {
@@ -37,6 +38,7 @@ const initialState: AuthState = {
   idToken: null,
   email: null,
   isLoading: false,
+  isLoggingOut: false,
 };
 
 // Async action to restore persisted auth state
@@ -84,6 +86,9 @@ const authSlice = createSlice({
       state.email = action.payload.email;
       state.isLoading = false;
     },
+    setLoggingOut: (state, action: { payload: boolean }) => {
+      state.isLoggingOut = action.payload;
+    },
     resetAll: () => initialState,
   },
   extraReducers: (builder) => {
@@ -103,5 +108,5 @@ const authSlice = createSlice({
   },
 });
 
-export const { setAuth, resetAll } = authSlice.actions;
+export const { setAuth, setLoggingOut, resetAll } = authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/hooks/useMyApps.ts
+++ b/frontend/hooks/useMyApps.ts
@@ -47,6 +47,7 @@ export const useMyApps = () => {
 
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [filteredApps, setFilteredApps] = useState(apps);
+  const [isLoading, setIsLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [currentAction, setCurrentAction] = useState<string | null>(null);
   const [progress, setProgress] = useState<{ done: number; total: number }>({
@@ -86,6 +87,8 @@ export const useMyApps = () => {
           "Initialization Error",
           "An error occurred while setting up the app. Please restart and try again."
         );
+      } finally {
+        setIsLoading(false);
       }
     };
 
@@ -181,6 +184,7 @@ export const useMyApps = () => {
     filteredApps,
     searchQuery,
     setSearchQuery,
+    isLoading,
     syncing,
     currentAction,
     progress,

--- a/frontend/hooks/useProfile.ts
+++ b/frontend/hooks/useProfile.ts
@@ -30,7 +30,7 @@ import { performLogout } from "@/utils/performLogout";
  */
 export const useProfile = () => {
   const dispatch = useDispatch<AppDispatch>();
-  const { accessToken } = useSelector((state: RootState) => state.auth);
+  const { accessToken, isLoggingOut } = useSelector((state: RootState) => state.auth);
   const { userInfo } = useSelector((state: RootState) => state.userInfo);
   
   const [basicUserInfo, setBasicUserInfo] = useState<BasicUserInfo>({
@@ -93,5 +93,6 @@ export const useProfile = () => {
   return {
     basicUserInfo,
     handleLogout,
+    isLoggingOut,
   };
 };

--- a/frontend/hooks/useStore.ts
+++ b/frontend/hooks/useStore.ts
@@ -56,8 +56,11 @@ export const useStore = () => {
   useEffect(() => {
     const initializeApps = async () => {
       setIsLoading(true);
-      if (accessToken) loadMicroAppDetails(dispatch, logout);
-      setIsLoading(false);
+      try {
+        if (accessToken) await loadMicroAppDetails(dispatch, logout);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
     initializeApps();

--- a/frontend/utils/performLogout.ts
+++ b/frontend/utils/performLogout.ts
@@ -15,7 +15,7 @@
 // under the License.
 import { APPS, AUTH_DATA, USER_INFO } from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
-import { resetAll } from "@/context/slices/authSlice";
+import { resetAll, setLoggingOut } from "@/context/slices/authSlice";
 import { persistor, RootState } from "@/context/store";
 import { logout } from "@/services/authService";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -33,10 +33,11 @@ import { getDevicePushToken } from "@/services/notificationService";
 export const performLogout = createAsyncThunk(
   "auth/logout",
   async (_, { dispatch, getState }) => {
+    dispatch(setLoggingOut(true));
     try {
       const state = getState() as RootState;
       const appIds = state.apps.apps.map((app) => app.appId);
-      
+
       // Deactivate device token before logout
       try {
         const userEmail = state.auth.email;
@@ -75,6 +76,7 @@ export const performLogout = createAsyncThunk(
       );
     } catch (error) {
       console.error("Logout error:", error);
+      dispatch(setLoggingOut(false));
     }
   }
 );


### PR DESCRIPTION
## Purpose
Closes #97

Several async operations gave the user no feedback while in flight: fetching the micro-apps list (both in the Store and My Apps screens) and signing out. Users had no indication anything was happening, and could still interact with the tab bar / navigate mid-logout.

## Goals
- Show skeleton loading placeholders while micro-app data is being fetched, on both the Store screen (available apps) and the My Apps screen (installed apps).
- Show a loading spinner on the Sign Out button and block tab bar interaction while sign-out is in progress.

## Approach
- Added `Skeleton`-based `ListItemSkeleton`/`ListItemSkeletonList` (row-style, for the Store screen's list layout) and `WidgetSkeleton`/`WidgetSkeletonGrid` (grid-style, for the My Apps screen's icon-grid layout) components.
- `useStore.ts`: fixed a bug where `loadMicroAppDetails()` was called without `await`, so `isLoading` was reset before the fetch actually completed — the skeleton had no real time window to render regardless of fetch duration.
- `useMyApps.ts`: added an `isLoading` state around the initial fetch, which previously had no loading state at all.
- `authSlice.ts`: added `isLoggingOut` state + `setLoggingOut` action; `performLogout.ts` dispatches it at the start/on error of the logout thunk (success path resets via the existing `resetAll()`).
- `profile.tsx`: Sign Out button shows a spinner + "Signing Out..." and is disabled while logging out.
- `(tabs)/_layout.tsx`: renders an absolutely-positioned transparent overlay over the tab bar while `isLoggingOut` is true, blocking all touches there regardless of the tab bar's internal press-handling. (An earlier attempt using `tabBarButton`'s `disabled` prop didn't reliably block navigation in testing, so the overlay is the actual guard.)

No UI changes to the native splash/app icon or other unrelated screens.

## User stories
As a user, when I open the Store or My Apps screen, I see a loading skeleton instead of a blank screen while data loads. When I sign out, I see clear feedback that it's in progress and can't accidentally navigate away mid-process.

## Release note
Added skeleton loading states for micro-app fetching (Store and My Apps screens) and loading feedback (spinner + disabled tab bar) during sign-out.

## Automation tests
- Integration tests: Verified manually via an EAS development build — confirmed skeletons render during fetch, sign-out spinner/disabled state work, and tab bar is correctly blocked during logout.

## Security checks
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Tested on a physical Android device via an EAS development build.