### PR TITLE
[Frontend]: Fix stale authenticated screen reachable via back button after logout

### DIFF
--- a/frontend/utils/performLogout.ts
+++ b/frontend/utils/performLogout.ts
@@ -68,7 +68,10 @@ export const performLogout = createAsyncThunk(
         [
           {
             text: "OK",
-            onPress: () => router.navigate(ScreenPaths.LOGIN),
+            onPress: () => {
+              router.dismissAll();
+              router.replace(ScreenPaths.LOGIN);
+            },
           },
         ],
         { cancelable: false }


### PR DESCRIPTION
## Purpose
Closes #98

After signing out, pressing the native Android back button could return the user into the previously active authenticated screen, still showing that user's data and fully interactive, until the app process was fully killed. Redux state was already reset on logout, but the navigation history still held the old authenticated route underneath.

## Goals
Ensure no authenticated screen remains reachable via back-navigation once a user has signed out.

## Approach
Root cause: `performLogout.ts` navigated to `login` via `router.navigate(ScreenPaths.LOGIN)`, which pushes `login` on top of the root stack instead of clearing it. Whatever was previously on top of the stack (`(tabs)`, or a pushed `micro-app` screen) remained in history underneath, so the native back button could pop back into it.

**Why `Stack.Protected` wasn't used:** the issue originally proposed gating `(tabs)`/`update`/`micro-app` behind `Stack.Protected` in `app/_layout.tsx` so they're never mounted while unauthenticated. `Stack.Protected` isn't available in the expo-router version this project is pinned to, though. It requires `expo-router@5.0.2+` (Expo SDK 53+), and this project is on `expo-router ~4.0.17` / SDK 52. I tried a JS-only substitute (conditionally rendering different `Stack.Screen` sets based on auth state), but it caused a native crash on device: `ScreenStackFragment added into a non-stack container`. This happens because `react-native-screens`' native stack on this version doesn't safely support swapping its entire set of `Stack.Screen` children in one render; that's effectively what `Stack.Protected` was later built upstream to handle correctly. Upgrading expo-router/Expo SDK to unlock it is a much larger, riskier change than this bug warrants, so that's left for a separate upgrade effort.

Instead, this fix resets the navigation history on logout, in `utils/performLogout.ts`:
```ts
onPress: () => {
  router.dismissAll();
  router.replace(ScreenPaths.LOGIN);
},
```
`dismissAll()` pops every screen pushed on top of the root stack back down to its first entry (covers logging out from a pushed `micro-app` screen, not just the Profile tab), and `replace()` then swaps that root entry for `login` instead of pushing on top of it. After logout, `login` is left as the only entry in the stack's history, so there's nothing authenticated left for the native back button to return to.

## User stories
As a user, after I sign out, pressing the back button does not return me to my account. No authenticated screen remains reachable.

## Release note
Fixed a bug where pressing the native back button after signing out could return to a previously authenticated screen still showing the signed-out user's data.

## Automation tests
- Integration tests: Verified manually via an EAS build. Logged out from the Profile tab, and separately from a pushed micro-app screen, then pressed the native back button in both cases and confirmed no authenticated screen remained in history.

## Security checks
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Tested on a physical Android device via an EAS build.