### PR TITLE
[Frontend]: Fix login screen briefly flashing on app launch even when signed in

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -39,10 +39,6 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
   const { showSplash, onAppLoadComplete } = useAppLayout();
 
-  if (showSplash) {
-    return <SplashModal loading={showSplash} animationType="fade" />;
-  }
-
   return (
     <SafeAreaProvider>
       <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
@@ -71,6 +67,9 @@ export default function RootLayout() {
             }
             translucent={false}
           />
+          {showSplash && (
+            <SplashModal loading={showSplash} animationType="fade" />
+          )}
         </>
       </ThemeProvider>
     </SafeAreaProvider>

--- a/frontend/hooks/useAppLayout.ts
+++ b/frontend/hooks/useAppLayout.ts
@@ -24,17 +24,16 @@ import { lockAsync, OrientationLock } from "expo-screen-orientation";
 export const useAppLayout = () => {
   const [isAppReady, setIsAppReady] = useState(false);
   const [isMinTimeElapsed, setIsMinTimeElapsed] = useState(false);
-  
+  const [isAuthResolved, setIsAuthResolved] = useState(false);
+
   const [fontsLoaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
 
-  // Called when all app initialization is done
+  // Called by AppInitializer once auth restoration has actually completed
   const onAppLoadComplete = useCallback(() => {
-    if (fontsLoaded) {
-      setIsAppReady(true);
-    }
-  }, [fontsLoaded]);
+    setIsAuthResolved(true);
+  }, []);
 
   // Minimum splash screen time
   useEffect(() => {
@@ -45,12 +44,13 @@ export const useAppLayout = () => {
     return () => clearTimeout(timer);
   }, []);
 
-  // Trigger initialization when fonts are ready
+  // The app is only ready once fonts are loaded AND auth state is resolved,
+  // so the splash never hides before authentication status is genuinely known.
   useEffect(() => {
-    if (fontsLoaded) {
-      onAppLoadComplete();
+    if (fontsLoaded && isAuthResolved) {
+      setIsAppReady(true);
     }
-  }, [fontsLoaded, onAppLoadComplete]);
+  }, [fontsLoaded, isAuthResolved]);
 
   // Lock screen orientation to portrait mode
   useEffect(() => {


### PR DESCRIPTION
## Purpose
Closes #99

On cold start, if a user is already signed in, the login screen briefly flashed before the app correctly showed the tabs/home screen. Even though the flash is brief, showing the wrong screen on every launch undermines confidence that auth state is handled correctly.

## Goals
The splash screen should never hide before the app's authentication status is genuinely known, so `app/index.tsx` never has a chance to redirect based on stale/unresolved auth state.

## Approach
Two issues combined to cause this, exactly as diagnosed in the issue:

1. `app/index.tsx` redirects based on `state.auth.accessToken`, which can render before `restoreAuth()` has actually resolved, redirecting to `/login` first and only correcting to `/(tabs)` shortly after.
2. `useAppLayout.ts` hid the splash based only on fonts being loaded, via a redundant effect that called `onAppLoadComplete()` independently whenever fonts finished loading, in addition to `AppInitializer` calling it once auth restoration completed. Since fonts typically load fast, the splash could hide before auth restoration actually finished.

Fix in `useAppLayout.ts`: removed the fonts-only path. `onAppLoadComplete` (called only by `AppInitializer`, only after `restoreAuth()` settles) now just marks auth as resolved; a single effect gates `isAppReady` on both fonts loaded AND auth resolved, so there's one authoritative source of truth tied to actual initialization completion.

This surfaced a second, previously-hidden bug in `app/_layout.tsx`: the root layout returned `<SplashModal>` early while `showSplash` was true, which meant `<AppInitializer>` never mounted until the splash was already gone — a circular dependency, since the splash could now only hide once `AppInitializer` had run. This used to work "by accident" because the old fonts-only path could flip the splash off independent of `AppInitializer` ever mounting, which is exactly the bug being fixed here. Resolved by always rendering the full tree (`Provider`/`PersistGate`/`AppInitializer`/`Stack`) and rendering `SplashModal` as an overlay on top instead of an early return, since it's a full-screen native `Modal` that already covers whatever is mounted underneath. This lets `AppInitializer` run in the background while the splash is up, with no visible flicker even if `index.tsx` redirects more than once behind the scenes.

## User stories
As a user who is already signed in, opening the app takes me straight to the home/tabs screen without a login screen flash in between.

## Release note
Fixed a bug where the login screen would briefly flash on app launch even when the user was already signed in.

## Automation tests
- Integration tests: Verified manually via an EAS build across repeated cold starts while already signed in; confirmed no login-screen flash and that the splash no longer hangs indefinitely.

## Security checks
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
Tested on a physical Android device via an EAS build.